### PR TITLE
Add option to use daily goal instead of monthly goal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ hours/**
 doc
 diagram.pdf
 coverage
+.idea/

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -152,6 +152,16 @@ class Punch
     "How many hours you want to work per month.",
     68
 
+  # @return [Float]
+  option :daily_goal,
+    "How many hours you want to work per day.",
+    8.4
+
+  # @return [Symbol]
+  option :goal_type,
+         "Whether you want the stats do use the daily or monthly goal.",
+         :monthly
+
   # @return [Array]
   option :workdays,
     "Which days you work on. Used for stats.",

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -159,7 +159,7 @@ class Punch
 
   # @return [Symbol]
   option :goal_type,
-         "Whether you want the stats do use the daily or monthly goal.",
+         "Whether you want the stats to use the daily or monthly goal.",
          :monthly
 
   # @return [Array]

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -86,7 +86,7 @@ class Stats
 
   def progress
     diff = Totals.format(remaining)
-    "#{percentage} % | #{Totals.format reached}/#{config.monthly_goal} | "\
+    "#{percentage} % | #{Totals.format reached}/#{Totals.format goal} | "\
       "Diff: #{diff}"
   end
 
@@ -122,7 +122,7 @@ class Stats
   end
 
   def percentage
-    (100.0 / monthly_goal * reached).round 2
+    (100.0 / goal * reached).round 2
   end
 
   def workdays
@@ -133,12 +133,20 @@ class Stats
     @monthly_goal ||= config.monthly_goal * 3600
   end
 
+  def goal
+    @goal ||= if config.goal_type == :monthly
+                config.monthly_goal
+              else
+                ((config.daily_goal * workdays.count ).round(2) * 3600).floor
+              end
+  end
+
   def reached
     @reached ||= month.total
   end
 
   def remaining
-    @remaining ||= monthly_goal - reached
+    @remaining ||= goal - reached
   end
 
   def hourly_pay


### PR DESCRIPTION
If you're working full time, configuring a monthly goal isn't really useful.
It makes more sense to use a daily goal and calculate the monthly from it, since not all months have equal workdays.