### PR TITLE
Fix totals format for negative numbers

### DIFF
--- a/lib/totals.rb
+++ b/lib/totals.rb
@@ -23,11 +23,14 @@ module Totals
   end
 
   def digital_format(seconds)
+    negative = seconds.negative?
+    seconds = seconds.abs
+
     hours   = seconds / 3_600
     rest    = seconds - (hours * 3_600)
     minutes = rest / 60
 
-    "#{hours.left_pad}:#{minutes.left_pad}"
+    "#{negative ? "-" : ""}#{hours.left_pad}:#{minutes.left_pad}"
   end
 
   def decimal_format(seconds)

--- a/test/stats_test.rb
+++ b/test/stats_test.rb
@@ -115,15 +115,15 @@ class StatsTest < PunchTest
         punch '8-17 -d 2'
         punch '8-17 -d 3'
         punch '8-17 -d 4'
-        punch '8-10'
+        punch '8-1030'
 
         # Not enough worked yet
-        assert_equal '02:00', stats.quota
+        assert_equal '01:30', stats.quota
 
-        punch '10-18'
+        punch '10-1820'
 
         # Worked too much
-        assert_equal '-6:00', stats.quota
+        assert_equal '-06:20', stats.quota
       end
     end
   end


### PR DESCRIPTION
Totals.format was broken for negative numbers. This PR addresses this and improves the quota test to check this.